### PR TITLE
Guard Windows event loop policy assignment

### DIFF
--- a/inb4404.py
+++ b/inb4404.py
@@ -400,11 +400,15 @@ def clean():
 
 def main():
     """Run the main function body."""
+    if hasattr(asyncio, "WindowsSelectorEventLoopPolicy") and sys.platform.startswith(
+        "win"
+    ):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     for i, url in enumerate(opts.thread, start=1):
         opts.archived_md5 = reload_archive()
         thread = DownloadableThread(i, url)
         thread.resolve_path()
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         asyncio.run(thread.download(), debug=False)
 
 


### PR DESCRIPTION
## Summary
- guard the Windows event loop policy assignment with a platform check so it only runs where available
- move the policy assignment outside the download loop to avoid redundant calls

## Testing
- python inb4404.py --help *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_b_68df9c44a18483318d673691d9e760db